### PR TITLE
Update install instructions to include latest scala version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Big differences:
 ### in your build.sbt
 
 ```scala
-libraryDependencies +=  "org.scalaj" %% "scalaj-http" % "1.1.5"
+libraryDependencies +=  "org.scalaj" %% "scalaj-http_2.11" % "1.1.5"
 ```
 
 ### maven


### PR DESCRIPTION
You can't install scalaj-http in build.sbt without the scala version appended to the package name. I figure if people are not using 2.11 they can know a little bit quicker to change it. Or we can always just go with <input version here>
